### PR TITLE
Fix missing "in transit" info

### DIFF
--- a/LtnManager/scripts/ltn-data.lua
+++ b/LtnManager/scripts/ltn-data.lua
@@ -418,7 +418,7 @@ local function iterate_in_transit(working_data, iterations_per_tick)
             local train_data = working_data.trains[delivery_id]
             if
                 train_data
-                and train_data.valid
+                and train_data.train.valid
                 and train_data.main_locomotive
                 and train_data.main_locomotive.surface
             then


### PR DESCRIPTION
I think there's a typo here - `train_data` doesn't have a `.valid` property and broke the `iterate_in_transit()` function