### PR TITLE
Fix detection of LTN Combinator Modernized

### DIFF
--- a/LtnManager/constants.lua
+++ b/LtnManager/constants.lua
@@ -145,7 +145,7 @@ if script then
   constants.open_station_gui_tooltip = {
     "",
     { "gui.ltnm-open-station-gui" },
-    remote.interfaces["ltn-combinator"] and { "", "\n", { "gui.ltnm-open-ltn-combinator-gui" } } or nil,
+    script.active_mods["LTN_Combinator_Modernized"] and { "", "\n", { "gui.ltnm-open-ltn-combinator-gui" } } or nil,
   }
 end
 


### PR DESCRIPTION
Moving to use core/lualib/event_handler.  Remote interfaces don't get until on_load / on_init.  Long after this bit of code runs.