### PR TITLE
fix: zoom in to scale 1 on shift+click on station

### DIFF
--- a/scripts/gui/actions.lua
+++ b/scripts/gui/actions.lua
@@ -109,7 +109,7 @@ function actions.open_station_gui(Gui, msg, e)
                 return
             end
         else
-            player.zoom_to_world(station_data.entity.position, station_data.surface_index, station_data.entity)
+            player.zoom_to_world(station_data.entity.position, 1, station_data.entity)
         end
 
         rendering.draw_circle({


### PR DESCRIPTION
fixes #224

During the attempt of implementing SE surface switching the scale parameter for the zoom_to_world call was accidentally left to something unrelated.

This PR reverts that to scale 1 as it was before.

Unrelated question: Does the follow parameter (station_data.entity) really do anything here, since stations are stationary (hehe) and thus I would expect follow to do nothing. (I have no idea what follow actually is supposed to do though)