### PR TITLE
fix/214 fix shift click on different surface

### DIFF
--- a/locale/en/LtnManager.cfg
+++ b/locale/en/LtnManager.cfg
@@ -73,6 +73,7 @@ ltnm-error-ltn-combinator-not-found=Could not find an LTN Combinator for this st
 ltnm-error-station-is-invalid=Station is invalid, please refresh the GUI.
 ltnm-error-train-is-invalid=Train is invalid, please refresh the GUI.
 ltnm-error-station-on-different-surface=Station is on a different surface and cannot be viewed.
+ltnm-error-station-on-different-surface-unknown-zone=La station se trouve sur une surface différente et sa zone ne peut être déterminée.
 
 [mod-description]
 LtnManager=A GUI for managing your Logistic Train Network.

--- a/locale/en/LtnManager.cfg
+++ b/locale/en/LtnManager.cfg
@@ -73,7 +73,7 @@ ltnm-error-ltn-combinator-not-found=Could not find an LTN Combinator for this st
 ltnm-error-station-is-invalid=Station is invalid, please refresh the GUI.
 ltnm-error-train-is-invalid=Train is invalid, please refresh the GUI.
 ltnm-error-station-on-different-surface=Station is on a different surface and cannot be viewed.
-ltnm-error-station-on-different-surface-unknown-zone=La station se trouve sur une surface différente et sa zone ne peut être déterminée.
+ltnm-error-station-on-different-surface-unknown-zone=Station is on a different surface and its zone cannot be determined.
 
 [mod-description]
 LtnManager=A GUI for managing your Logistic Train Network.

--- a/locale/fr/LtnManager.cfg
+++ b/locale/fr/LtnManager.cfg
@@ -73,6 +73,7 @@ ltnm-error-ltn-combinator-not-found=Impossible de trouver un LTN Combinator pour
 ltnm-error-station-is-invalid=Cette gare est invalide, veuillez rafraîchir l'interface.
 ltnm-error-train-is-invalid=Ce train est invalide, veuillez rafraîchir l'interface.
 ltnm-error-station-on-different-surface=La station est sur une surface différente et ne peut pas être vue.
+ltnm-error-station-on-different-surface-unknown-zone=La station se trouve sur une surface différente et sa zone ne peut être déterminée.
 
 [mod-description]
 LtnManager=Une interface graphique pour gérer votre réseau ferroviaire logistique.

--- a/scripts/gui/actions.lua
+++ b/scripts/gui/actions.lua
@@ -93,16 +93,19 @@ function actions.open_station_gui(Gui, msg, e)
                 remote.interfaces["space-exploration"]
                 and remote.call("space-exploration", "remote_view_is_unlocked", { player = player })
             then
-                local surface = game.surfaces[station_data.surface_index]
-                if surface then
-                    local surface_name = surface.name
+                local zone = remote.call("space-exploration", "get_zone_from_surface_index",
+                    { surface_index = station_data.surface_index })
+                if zone then
                     remote.call("space-exploration", "remote_view_start", {
                         player = player,
-                        zone_name = surface_name,
+                        zone_name = zone.name,
                         position = station_data.entity.position,
                         location_name = station_data.name,
                         freeze_history = true,
                     })
+                else
+                    util.error_flying_text(player, { "message.ltnm-error-station-on-different-surface-unknown-zone" })
+                    return
                 end
             else
                 util.error_flying_text(player, { "message.ltnm-error-station-on-different-surface" })

--- a/scripts/gui/actions.lua
+++ b/scripts/gui/actions.lua
@@ -105,7 +105,7 @@ function actions.open_station_gui(Gui, msg, e)
                     })
                 end
             else
-                util.error_flying_text(player({ "message.ltnm-error-station-on-different-surface" }))
+                util.error_flying_text(player, { "message.ltnm-error-station-on-different-surface" })
                 return
             end
         else


### PR DESCRIPTION
Space Exploration mod call "remote_view_start" expects the zone_name argument to be a zone name which is different from surface names. (For example "Nauvis" (zone name) instead of "nauvis"(surface name))
To get the zone name we use the surface index and call into the remote function `get_zone_from_surface_index`.
    
fixes #214 214

For the french translation I used deepl.com, please double-check it and fix it, as I don't speak french well enough to be sure of anything.

Also fixes a wrong syntax for the `util.error_flying_text` call in one of the error branches.